### PR TITLE
Feature/default transport

### DIFF
--- a/bns-core/src/transports/default.rs
+++ b/bns-core/src/transports/default.rs
@@ -27,7 +27,8 @@ pub struct DefaultTransport {
     pub pending_candidates: Arc<Mutex<Vec<RTCIceCandidate>>>,
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl IceTransport for DefaultTransport {
     type Connection = RTCPeerConnection;
     type Candidate = RTCIceCandidate;
@@ -151,7 +152,8 @@ impl IceTransport for DefaultTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl IceTransportBuilder for DefaultTransport {
     fn new() -> Self {
         Self {

--- a/bns-core/src/transports/default.rs
+++ b/bns-core/src/transports/default.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use anyhow::Result;
 use async_trait::async_trait;
 
-
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -66,13 +65,11 @@ impl IceTransport for DefaultTransport {
 
     async fn get_data_channel(&self, label: &str) -> Result<Arc<RTCDataChannel>> {
         match self.get_peer_connection().await {
-            Some(peer_connection) => {
-                peer_connection
-                    .create_data_channel(label, None)
-                    .await
-                    .map_err(|e| anyhow!(e))
-            },
-            None => Err(anyhow!("cannot get data channel"))
+            Some(peer_connection) => peer_connection
+                .create_data_channel(label, None)
+                .await
+                .map_err(|e| anyhow!(e)),
+            None => Err(anyhow!("cannot get data channel")),
         }
     }
 
@@ -97,7 +94,7 @@ impl IceTransport for DefaultTransport {
             Some(peer_connection) => peer_connection
                 .set_remote_description(desc.into())
                 .await
-            .map_err(|e| anyhow!(e)),
+                .map_err(|e| anyhow!(e)),
             None => Err(anyhow!("connection is not setup")),
         }
     }
@@ -154,10 +151,8 @@ impl IceTransport for DefaultTransport {
     }
 }
 
-
 #[async_trait(?Send)]
 impl IceTransportBuilder for DefaultTransport {
-
     fn new() -> Self {
         return Self {
             connection: Arc::new(Mutex::new(None)),
@@ -179,8 +174,8 @@ impl IceTransportBuilder for DefaultTransport {
                 let mut conn = self.connection.lock().await;
                 *conn = Some(Arc::new(c));
                 Ok(())
-            },
-            Err(e) => Err(anyhow!(e))
+            }
+            Err(e) => Err(anyhow!(e)),
         }
     }
 }

--- a/bns-core/src/transports/default.rs
+++ b/bns-core/src/transports/default.rs
@@ -154,10 +154,10 @@ impl IceTransport for DefaultTransport {
 #[async_trait(?Send)]
 impl IceTransportBuilder for DefaultTransport {
     fn new() -> Self {
-        return Self {
+        Self {
             connection: Arc::new(Mutex::new(None)),
             pending_candidates: Arc::new(Mutex::new(vec![])),
-        };
+        }
     }
 
     async fn start(&mut self) -> Result<()> {

--- a/bns-core/src/transports/default.rs
+++ b/bns-core/src/transports/default.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use anyhow::Result;
 use async_trait::async_trait;
-use core::ops::Deref;
+
 
 use std::future::Future;
 use std::pin::Pin;

--- a/bns-core/src/transports/wasm.rs
+++ b/bns-core/src/transports/wasm.rs
@@ -25,8 +25,6 @@ pub struct WasmTransport {
     pub channel: Option<Arc<RtcDataChannel>>,
 }
 
-unsafe impl Sync for WasmTransport {}
-
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
 impl IceTransport for WasmTransport {

--- a/bns-core/src/transports/wasm.rs
+++ b/bns-core/src/transports/wasm.rs
@@ -18,7 +18,6 @@ use web_sys::RtcIceCandidate;
 
 use web_sys::RtcPeerConnection;
 
-
 #[derive(Clone)]
 pub struct WasmTransport {
     pub connection: Option<Arc<RtcPeerConnection>>,
@@ -112,7 +111,6 @@ impl IceTransport for WasmTransport {
 
 #[async_trait(?Send)]
 impl IceTransportBuilder for WasmTransport {
-
     fn new() -> Self {
         let mut config = RtcConfiguration::new();
         config.ice_servers(
@@ -135,7 +133,6 @@ impl IceTransportBuilder for WasmTransport {
         self.setup_channel("bns").await;
         return Ok(());
     }
-
 }
 impl WasmTransport {
     pub async fn setup_offer(&mut self) -> &Self {

--- a/bns-core/src/transports/wasm.rs
+++ b/bns-core/src/transports/wasm.rs
@@ -27,7 +27,8 @@ pub struct WasmTransport {
 
 unsafe impl Sync for WasmTransport {}
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl IceTransport for WasmTransport {
     type Connection = RtcPeerConnection;
     type Candidate = RtcIceCandidate;
@@ -109,7 +110,8 @@ impl IceTransport for WasmTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl IceTransportBuilder for WasmTransport {
     fn new() -> Self {
         let mut config = RtcConfiguration::new();
@@ -134,6 +136,7 @@ impl IceTransportBuilder for WasmTransport {
         return Ok(());
     }
 }
+
 impl WasmTransport {
     pub async fn setup_offer(&mut self) -> &Self {
         if let Some(connection) = &self.connection {

--- a/bns-core/src/types/ice_transport.rs
+++ b/bns-core/src/types/ice_transport.rs
@@ -5,7 +5,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 pub trait IceTransport {
     type Connection;
     type Candidate;
@@ -52,7 +53,8 @@ pub trait IceTransport {
     ) -> Result<()>;
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 pub trait IceTransportBuilder {
     fn new() -> Self;
     async fn start(&mut self) -> Result<()>;

--- a/bns-core/src/types/ice_transport.rs
+++ b/bns-core/src/types/ice_transport.rs
@@ -13,6 +13,8 @@ pub trait IceTransport {
     type Channel;
     type ConnectionState;
 
+    fn new() -> Self;
+    async fn start(&mut self) -> Result<()>;
     async fn get_peer_connection(&self) -> Option<Arc<Self::Connection>>;
     async fn get_pending_candidates(&self) -> Vec<Self::Candidate>;
     async fn get_answer(&self) -> Result<Self::Sdp>;

--- a/bns-core/src/types/ice_transport.rs
+++ b/bns-core/src/types/ice_transport.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait IceTransport {
     type Connection;
     type Candidate;
@@ -13,8 +13,6 @@ pub trait IceTransport {
     type Channel;
     type ConnectionState;
 
-    fn new() -> Self;
-    async fn start(&mut self) -> Result<()>;
     async fn get_peer_connection(&self) -> Option<Arc<Self::Connection>>;
     async fn get_pending_candidates(&self) -> Vec<Self::Candidate>;
     async fn get_answer(&self) -> Result<Self::Sdp>;
@@ -52,4 +50,10 @@ pub trait IceTransport {
                 + Sync,
         >,
     ) -> Result<()>;
+}
+
+#[async_trait(?Send)]
+pub trait IceTransportBuilder {
+    fn new() -> Self;
+    async fn start(&mut self) -> Result<()>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bns_core::transports::default::DefaultTransport;
+use bns_core::types::ice_transport::IceTransportBuilder;
 use bns_core::types::ice_transport::IceTransport;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::Server;
@@ -20,7 +21,8 @@ async fn main() -> Result<()> {
     let http_addr = "0.0.0.0:60000";
     let remote_addr = "0.0.0.0:50000";
 
-    let ice_transport = DefaultTransport::new().await?;
+    let mut ice_transport = DefaultTransport::new();
+    ice_transport.start().await?;
     let peer_connection = Arc::downgrade(&ice_transport.get_peer_connection().await.unwrap());
     let pending_candidates = ice_transport.get_pending_candidates().await;
     let (done_tx, mut done_rx) = tokio::sync::mpsc::channel::<()>(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bns_core::transports::default::DefaultTransport;
-use bns_core::types::ice_transport::IceTransportBuilder;
 use bns_core::types::ice_transport::IceTransport;
+use bns_core::types::ice_transport::IceTransportBuilder;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::Server;
 use webrtc::data_channel::data_channel_message::DataChannelMessage;


### PR DESCRIPTION
1. async_trait should be mark as `?Send`, for wasm compatibility (ref: https://github.com/rustwasm/wasm-bindgen/issues/2409)
2. Modified DefaultTransport to

```
#[derive(Clone)]
pub struct DefaultTransport {
    pub connection: Arc<Mutex<Option<Arc<RTCPeerConnection>>>>,
    pub pending_candidates: Arc<Mutex<Vec<RTCIceCandidate>>>,
}
```