### PR TITLE
Test/some tests about ice transport availability

### DIFF
--- a/bns-core/src/message/handler.rs
+++ b/bns-core/src/message/handler.rs
@@ -121,7 +121,7 @@ impl MessageHandler {
                 .await?;
 
                 trans.wait_for_connected(20, 3).await?;
-                self.swarm.get_or_register(&msg.sender_id, trans);
+                self.swarm.get_or_register(&msg.sender_id, trans).await?;
 
                 Ok(())
             }

--- a/bns-core/src/transports/default/mod.rs
+++ b/bns-core/src/transports/default/mod.rs
@@ -1,4 +1,4 @@
-mod transport;
+pub mod transport;
 
 use super::helper::IceCandidateSerializer;
 pub use transport::DefaultTransport;

--- a/bns-core/src/transports/default/transport.rs
+++ b/bns-core/src/transports/default/transport.rs
@@ -53,7 +53,6 @@ impl IceTransport<AcChannel> for DefaultTransport {
     type Sdp = RTCSessionDescription;
     type DataChannel = RTCDataChannel;
     type IceConnectionState = RTCIceConnectionState;
-    type ConnectionState = RTCPeerConnectionState;
     type Msg = DataChannelMessage;
 
     fn new(ch: Arc<AcChannel>) -> Self {
@@ -69,10 +68,10 @@ impl IceTransport<AcChannel> for DefaultTransport {
         Arc::clone(&self.signaler)
     }
 
-    async fn start(&mut self, stun: String) -> Result<&Self> {
+    async fn start(&mut self, stun: &str) -> Result<&Self> {
         let config = RTCConfiguration {
             ice_servers: vec![RTCIceServer {
-                urls: vec![stun.to_owned()],
+                urls: vec![stun.into()],
                 ..Default::default()
             }],
             ice_candidate_pool_size: 100,
@@ -245,7 +244,7 @@ impl DefaultTransport {
 impl IceTransportCallback<AcChannel> for DefaultTransport {
     type OnLocalCandidateHdlrFn = Box<dyn FnMut(Option<Self::Candidate>) -> Fut + Send + Sync>;
     type OnPeerConnectionStateChangeHdlrFn =
-        Box<dyn FnMut(Self::ConnectionState) -> Fut + Send + Sync>;
+        Box<dyn FnMut(RTCPeerConnectionState) -> Fut + Send + Sync>;
     type OnDataChannelHdlrFn = Box<dyn FnMut(Arc<Self::DataChannel>) -> Fut + Send + Sync>;
 
     async fn apply_callback(&self) -> Result<&Self> {
@@ -397,14 +396,109 @@ impl IceTrickleScheme<AcChannel> for DefaultTransport {
         let mut interval = time::interval(time::Duration::from_secs(interval_secs));
 
         for _ in 1..times {
-            if let Some(peer_connection) = self.get_peer_connection().await {
-                if peer_connection.connection_state() == RTCPeerConnectionState::Connected {
-                    return Ok(());
-                }
+            if self.is_connected().await {
+                return Ok(());
             };
             interval.tick().await;
         }
 
         Err(anyhow!("Not connected in time"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DefaultTransport as Transport;
+    use super::*;
+    use crate::channels::default::AcChannel as Channel;
+    use crate::types::channel::Channel as ChannelTrait;
+
+    async fn prepare_transport() -> Result<Transport> {
+        let ch = Arc::new(Channel::new(1));
+        let mut trans = Transport::new(ch);
+        let stun = "stun:stun.l.google.com:19302";
+        trans.start(stun).await?.apply_callback().await?;
+        Ok(trans)
+    }
+
+    async fn establish_connection(transport1: Transport, transport2: Transport) -> Result<()> {
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+
+        // Generate key pairs for signing and verification
+        let key1 = SecretKey::random();
+        let key2 = SecretKey::random();
+
+        // Peer 1 try to connect peer 2
+        let handshake_info1 = transport1
+            .get_handshake_info(key1, RTCSdpType::Offer)
+            .await?;
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+
+        // Peer 2 got offer then register
+        let addr1 = transport2.register_remote_info(handshake_info1).await?;
+        assert_eq!(addr1, key1.address());
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+
+        // Peer 2 create answer
+        let handshake_info2 = transport2
+            .get_handshake_info(key2, RTCSdpType::Answer)
+            .await?;
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::Checking)
+        );
+
+        // Peer 1 got answer then register
+        let addr2 = transport1.register_remote_info(handshake_info2).await?;
+        assert_eq!(addr2, key2.address());
+
+        transport1.wait_for_connected(5, 3).await?;
+        transport2.wait_for_connected(5, 3).await?;
+
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::Connected)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::Connected)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ice_connection_establish() -> Result<()> {
+        let transport1 = prepare_transport().await?;
+        let transport2 = prepare_transport().await?;
+
+        establish_connection(transport1, transport2).await?;
+
+        Ok(())
     }
 }

--- a/bns-core/src/transports/default/transport.rs
+++ b/bns-core/src/transports/default/transport.rs
@@ -106,6 +106,13 @@ impl IceTransport<AcChannel> for DefaultTransport {
             .map(|pc| pc.ice_connection_state())
     }
 
+    async fn is_connected(&self) -> bool {
+        self.ice_connection_state()
+            .await
+            .map(|s| s == RTCIceConnectionState::Connected)
+            .unwrap_or(false)
+    }
+
     async fn get_peer_connection(&self) -> Option<Arc<RTCPeerConnection>> {
         self.connection.lock().await.clone()
     }
@@ -407,7 +414,7 @@ impl IceTrickleScheme<AcChannel> for DefaultTransport {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::DefaultTransport as Transport;
     use super::*;
     use crate::channels::default::AcChannel as Channel;
@@ -421,7 +428,10 @@ mod tests {
         Ok(trans)
     }
 
-    async fn establish_connection(transport1: Transport, transport2: Transport) -> Result<()> {
+    pub async fn establish_connection(
+        transport1: &Transport,
+        transport2: &Transport,
+    ) -> Result<()> {
         assert_eq!(
             transport1.ice_connection_state().await,
             Some(RTCIceConnectionState::New)
@@ -497,7 +507,7 @@ mod tests {
         let transport1 = prepare_transport().await?;
         let transport2 = prepare_transport().await?;
 
-        establish_connection(transport1, transport2).await?;
+        establish_connection(&transport1, &transport2).await?;
 
         Ok(())
     }

--- a/bns-core/src/transports/wasm/transport.rs
+++ b/bns-core/src/transports/wasm/transport.rs
@@ -95,6 +95,13 @@ impl IceTransport<CbChannel> for WasmTransport {
             .map(|pc| pc.ice_connection_state())
     }
 
+    async fn is_connected(&self) -> bool {
+        self.ice_connection_state()
+            .await
+            .map(|s| s == RtcIceConnectionState::Connected)
+            .unwrap_or(false)
+    }
+
     async fn get_peer_connection(&self) -> Option<Arc<Self::Connection>> {
         self.connection.as_ref().map(|c| Arc::clone(c))
     }

--- a/bns-core/src/transports/wasm/transport.rs
+++ b/bns-core/src/transports/wasm/transport.rs
@@ -57,11 +57,6 @@ impl IceTransport<CbChannel> for WasmTransport {
     type IceConnectionState = RtcIceConnectionState;
     type Msg = JsValue;
 
-    // TODO: This is a wrong type define.
-    // Callback `on_peer_connection_state_change_callback` should use RtcPeerConnectionState.
-    // See also implementation in default.
-    type ConnectionState = RtcIceConnectionState;
-
     fn new(ch: Arc<CbChannel>) -> Self {
         Self {
             connection: None,
@@ -75,7 +70,7 @@ impl IceTransport<CbChannel> for WasmTransport {
         Arc::clone(&self.signaler)
     }
 
-    async fn start(&mut self, stun: String) -> Result<&Self> {
+    async fn start(&mut self, stun: &str) -> Result<&Self> {
         let mut config = RtcConfiguration::new();
         config.ice_servers(&JsValue::from_serde(&json! {[{"urls": stun}]}).unwrap());
 

--- a/bns-core/src/types/ice_transport.rs
+++ b/bns-core/src/types/ice_transport.rs
@@ -15,12 +15,11 @@ pub trait IceTransport<Ch: Channel> {
     type Sdp;
     type DataChannel;
     type IceConnectionState;
-    type ConnectionState;
     type Msg;
 
     fn new(signaler: Arc<Ch>) -> Self;
     fn signaler(&self) -> Arc<Ch>;
-    async fn start(&mut self, stun_addr: String) -> Result<&Self>;
+    async fn start(&mut self, stun_addr: &str) -> Result<&Self>;
     async fn close(&self) -> Result<()>;
     async fn ice_connection_state(&self) -> Option<Self::IceConnectionState>;
 

--- a/bns-core/src/types/ice_transport.rs
+++ b/bns-core/src/types/ice_transport.rs
@@ -22,6 +22,7 @@ pub trait IceTransport<Ch: Channel> {
     async fn start(&mut self, stun_addr: &str) -> Result<&Self>;
     async fn close(&self) -> Result<()>;
     async fn ice_connection_state(&self) -> Option<Self::IceConnectionState>;
+    async fn is_connected(&self) -> bool;
 
     async fn get_peer_connection(&self) -> Option<Arc<Self::Connection>>;
     async fn get_pending_candidates(&self) -> Vec<Self::Candidate>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ async fn run(http_addr: String, key: SecretKey, stun: &str) {
     let dht = Arc::new(Mutex::new(Chord::new(key.address().into())));
     let swarm = Arc::new(Swarm::new(
         Arc::new(AcChannel::new(1)),
-        stun.to_string(),
+        stun,
         key,
     ));
 
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
 
     let key = SecretKey::try_from(args.eth_key.as_str())?;
 
-    run(args.http_addr, key, &args.stun_server).await;
+    run(args.http_addr, key, args.stun_server.as_str()).await;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,11 +38,7 @@ pub struct Args {
 
 async fn run(http_addr: String, key: SecretKey, stun: &str) {
     let dht = Arc::new(Mutex::new(Chord::new(key.address().into())));
-    let swarm = Arc::new(Swarm::new(
-        Arc::new(AcChannel::new(1)),
-        stun,
-        key,
-    ));
+    let swarm = Arc::new(Swarm::new(Arc::new(AcChannel::new(1)), stun, key));
 
     let listen_event = MessageHandler::new(dht.clone(), swarm.clone());
     //let stabilize_event = MessageHandler::new(dht.clone(), swarm.clone());

--- a/src/service/discovery.rs
+++ b/src/service/discovery.rs
@@ -55,7 +55,7 @@ async fn handshake(swarm: Arc<Swarm>, key: SecretKey, data: Vec<u8>) -> anyhow::
             let resp = transport.get_handshake_info(key, RTCSdpType::Answer).await;
             match resp {
                 Ok(info) => {
-                    swarm.register(&addr, Arc::clone(&transport)).await;
+                    swarm.register(&addr, Arc::clone(&transport)).await?;
                     anyhow::Result::Ok(info.try_into()?)
                 }
                 Err(e) => {
@@ -99,7 +99,7 @@ pub async fn trickle_forward(
             let addr = transport
                 .register_remote_info(String::from_utf8(resp.as_bytes().to_vec())?.try_into()?)
                 .await?;
-            swarm.register(&addr, Arc::clone(&transport)).await;
+            swarm.register(&addr, Arc::clone(&transport)).await?;
             Ok("ok".to_string())
         }
         Err(e) => {


### PR DESCRIPTION
Declare that all transports registered should be connected.
Test the `wait_for_connect` function with a basic local establish procedure.