### PR TITLE
Refactor/channel enhancement

### DIFF
--- a/bns-core/src/channels/default.rs
+++ b/bns-core/src/channels/default.rs
@@ -1,20 +1,19 @@
 use crate::types::channel::Channel;
-use crate::types::channel::Event;
 use anyhow::Result;
 use async_channel as ac;
 use async_channel::Receiver;
 use async_channel::Sender;
 use async_trait::async_trait;
 
-pub struct AcChannel {
-    sender: Sender<Event>,
-    receiver: Receiver<Event>,
+pub struct AcChannel<T> {
+    sender: Sender<T>,
+    receiver: Receiver<T>,
 }
 
 #[async_trait]
-impl Channel for AcChannel {
-    type Sender = Sender<Event>;
-    type Receiver = Receiver<Event>;
+impl<T> Channel for AcChannel<T> {
+    type Sender = Sender<T>;
+    type Receiver = Receiver<T>;
 
     fn new(buffer: usize) -> Self {
         let (tx, rx) = ac::bounded(buffer);
@@ -31,12 +30,8 @@ impl Channel for AcChannel {
     fn receiver(&self) -> Self::Receiver {
         self.receiver.clone()
     }
+}
 
-    async fn send(&self, e: Event) -> Result<()> {
-        Ok(self.sender.send(e).await?)
-    }
-
-    async fn recv(&self) -> Result<Event> {
-        self.receiver().recv().await.map_err(|e| anyhow::anyhow!(e))
-    }
+pub async fn recv<T>(receiver: &Receiver<T>) -> Result<T> {
+    receiver.recv().await.map_err(|e| anyhow::anyhow!(e))
 }

--- a/bns-core/src/message/handler.rs
+++ b/bns-core/src/message/handler.rs
@@ -4,7 +4,7 @@ use crate::message::{
     MessageRelay, MessageRelayMethod, MessageSessionRelayProtocol, NotifiedPredecessor,
     NotifyPredecessor,
 };
-use crate::swarm::Swarm;
+use crate::swarm::{Swarm, TransportManager};
 use crate::types::ice_transport::IceTrickleScheme;
 use anyhow::anyhow;
 use anyhow::Result;

--- a/bns-core/src/types/channel.rs
+++ b/bns-core/src/types/channel.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use async_trait::async_trait;
 
 #[derive(Debug, Clone)]
@@ -16,6 +15,4 @@ pub trait Channel {
     fn new(buffer: usize) -> Self;
     fn sender(&self) -> Self::Sender;
     fn receiver(&self) -> Self::Receiver;
-    async fn send(&self, e: Event) -> Result<()>;
-    async fn recv(&self) -> Result<Event>;
 }

--- a/bns-core/src/types/ice_transport.rs
+++ b/bns-core/src/types/ice_transport.rs
@@ -17,8 +17,7 @@ pub trait IceTransport<Ch: Channel> {
     type IceConnectionState;
     type Msg;
 
-    fn new(signaler: Arc<Ch>) -> Self;
-    fn signaler(&self) -> Arc<Ch>;
+    fn new(event_sender: Ch::Sender) -> Self;
     async fn start(&mut self, stun_addr: &str) -> Result<&Self>;
     async fn close(&self) -> Result<()>;
     async fn ice_connection_state(&self) -> Option<Self::IceConnectionState>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
 #![feature(async_closure)]
 use anyhow::Result;
-use bns_core::channels::default::AcChannel;
 use bns_core::dht::Chord;
 use bns_core::ecc::SecretKey;
 use bns_core::message::handler::MessageHandler;
 use bns_core::swarm::Swarm;
-use bns_core::types::channel::Channel;
 use bns_node::logger::Logger;
 use bns_node::service::run_service;
 use clap::Parser;
@@ -38,7 +36,7 @@ pub struct Args {
 
 async fn run(http_addr: String, key: SecretKey, stun: &str) {
     let dht = Arc::new(Mutex::new(Chord::new(key.address().into())));
-    let swarm = Arc::new(Swarm::new(Arc::new(AcChannel::new(1)), stun, key));
+    let swarm = Arc::new(Swarm::new(stun, key));
 
     let listen_event = MessageHandler::new(dht.clone(), swarm.clone());
     //let stabilize_event = MessageHandler::new(dht.clone(), swarm.clone());

--- a/src/service/discovery.rs
+++ b/src/service/discovery.rs
@@ -2,7 +2,7 @@ use crate::service::http_error::HttpError;
 use anyhow::anyhow;
 use axum::extract::{Extension, Query, RawBody};
 use bns_core::ecc::SecretKey;
-use bns_core::swarm::Swarm;
+use bns_core::swarm::{Swarm, TransportManager};
 use bns_core::types::ice_transport::IceTrickleScheme;
 use std::collections::HashMap;
 use std::sync::Arc;


### PR DESCRIPTION
1. If the transport only sends events, then only a sender is needed.
2. Abstract channel to use it in message handler.