### PR TITLE
Chore/move tokio to dev dependencies

### DIFF
--- a/bns-core/Cargo.toml
+++ b/bns-core/Cargo.toml
@@ -4,13 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["webrtc", "tokio", "tokio-util", "bytes", "async-channel"]
-wasm = [
-  "web-sys",
-  "wasm-bindgen",
-  "js-sys",
-  "wasm-bindgen-futures",
-]
+default = ["webrtc", "bytes", "async-channel"]
+wasm = ["web-sys", "wasm-bindgen", "js-sys", "wasm-bindgen-futures"]
 
 [dependencies]
 # global
@@ -29,14 +24,13 @@ futures = { version = "0.3.21" }
 chrono = { version = "0.4.19", features = ["wasmbind"] }
 base58-monero = { version = "0.3", default-features = false, features = ["check"] }
 async-stream = "0.3.2"
+async-lock = "2.5.0"
 futures-core = "0.3.21"
 url = { version = "2", features = ["serde"] }
 thiserror = "1"
 
 # default
 webrtc = { version = "0.3.3", optional = true }
-tokio = { version = "1.13.0", features = ["full"], optional = true }
-tokio-util = { version = "0.6.9", optional = true }
 bytes = { version = "1.1.0", optional = true }
 async-channel = { version = "1.6.1", optional = true }
 
@@ -71,16 +65,19 @@ features = [
 
 [target.'cfg(target_family="wasm")'.dependencies]
 web3 = { package = "web3", version = "0.18.0", features = ["wasm"], default-features = false }
-futures-util = {package="futures-util", version="0.3.21", default-features=false}
-uuid = { package = "uuid", version = "0.8.2", features = ["wasm-bindgen", "v4"]}
+futures-util = { package = "futures-util", version = "0.3.21", default-features = false }
+uuid = { package = "uuid", version = "0.8.2", features = ["wasm-bindgen", "v4"] }
 
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 web3 = { package = "web3", version = "0.18.0" }
-futures-util = {package="futures-util", version="0.3.21"}
-uuid = { package = "uuid", version = "0.8.2", features = ["v4"]}
+futures-util = { package = "futures-util", version = "0.3.21" }
+uuid = { package = "uuid", version = "0.8.2", features = ["v4"] }
 
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
 console_log = { version = "0.2", features = ["color"] }
+
+[target.'cfg(not(target_family="wasm"))'.dev-dependencies]
+tokio = { version = "1.13.0", features = ["full"] }


### PR DESCRIPTION
wasm:
```shell
❯ cargo tree -i tokio --target=wasm32-unknown-unknown --features wasm --no-default-features
[no outputs]
```

default:
```shell
❯ cargo tree -i tokio
tokio v1.17.0
├── h2 v0.3.13
│   ├── hyper v0.14.18
│   │   ├── hyper-tls v0.5.0
│   │   │   └── reqwest v0.11.10
│   │   │       └── web3 v0.18.0
│   │   │           └── bns-core v0.1.0 (/Users/magine/Projects/rust/bns-node/bns-core)
│   │   └── reqwest v0.11.10 (*)
│   └── reqwest v0.11.10 (*)
├── hyper v0.14.18 (*)
├── hyper-tls v0.5.0 (*)
├── interceptor v0.7.6
│   └── webrtc v0.3.4
│       └── bns-core v0.1.0 (/Users/magine/Projects/rust/bns-node/bns-core)
├── reqwest v0.11.10 (*)
├── stun v0.4.2
│   ├── turn v0.5.4
│   │   ├── webrtc v0.3.4 (*)
│   │   └── webrtc-ice v0.6.6
│   │       └── webrtc v0.3.4 (*)
│   ├── webrtc v0.3.4 (*)
│   └── webrtc-ice v0.6.6 (*)
├── tokio-native-tls v0.3.0
│   ├── hyper-tls v0.5.0 (*)
│   └── reqwest v0.11.10 (*)
├── tokio-stream v0.1.8
│   └── web3 v0.18.0 (*)
├── tokio-util v0.6.9
│   └── web3 v0.18.0 (*)
├── tokio-util v0.7.1
│   └── h2 v0.3.13 (*)
├── turn v0.5.4 (*)
├── web3 v0.18.0 (*)
├── web3-async-native-tls v0.4.0
│   └── web3 v0.18.0 (*)
├── webrtc v0.3.4 (*)
├── webrtc-data v0.3.3
│   └── webrtc v0.3.4 (*)
├── webrtc-dtls v0.5.2
│   └── webrtc v0.3.4 (*)
├── webrtc-ice v0.6.6 (*)
├── webrtc-mdns v0.4.2
│   ├── webrtc v0.3.4 (*)
│   └── webrtc-ice v0.6.6 (*)
├── webrtc-sctp v0.4.3
│   ├── webrtc v0.3.4 (*)
│   └── webrtc-data v0.3.3 (*)
├── webrtc-srtp v0.8.9
│   ├── interceptor v0.7.6 (*)
│   └── webrtc v0.3.4 (*)
└── webrtc-util v0.5.3
    ├── interceptor v0.7.6 (*)
    ├── rtcp v0.6.5
    │   ├── interceptor v0.7.6 (*)
    │   ├── webrtc v0.3.4 (*)
    │   └── webrtc-srtp v0.8.9 (*)
    ├── rtp v0.6.5
    │   ├── interceptor v0.7.6 (*)
    │   ├── webrtc v0.3.4 (*)
    │   ├── webrtc-media v0.4.5
    │   │   └── webrtc v0.3.4 (*)
    │   └── webrtc-srtp v0.8.9 (*)
    ├── stun v0.4.2 (*)
    ├── turn v0.5.4 (*)
    ├── webrtc v0.3.4 (*)
    ├── webrtc-data v0.3.3 (*)
    ├── webrtc-dtls v0.5.2 (*)
    ├── webrtc-ice v0.6.6 (*)
    ├── webrtc-mdns v0.4.2 (*)
    ├── webrtc-media v0.4.5 (*)
    ├── webrtc-sctp v0.4.3 (*)
    └── webrtc-srtp v0.8.9 (*)
[dev-dependencies]
└── bns-core v0.1.0 (/Users/magine/Projects/rust/bns-node/bns-core)
```