### PR TITLE
use Arc<self> instead self

### DIFF
--- a/bin/daemon.rs
+++ b/bin/daemon.rs
@@ -103,7 +103,7 @@ async fn run_jobs(args: &RunArgs) -> anyhow::Result<()> {
     let key = key.to_owned();
     let http_addr = args.http_addr.to_owned();
     if args.disable_turn {
-        let (_, _) = futures::join!(async { listen_event.listen().await }, async {
+        let (_, _) = futures::join!(async { Arc::new(listen_event).listen().await }, async {
             run_service(http_addr.to_owned(), swarm_clone, key).await
         },);
     } else {
@@ -113,7 +113,7 @@ async fn run_jobs(args: &RunArgs) -> anyhow::Result<()> {
         let password: &str = &args.password;
         let realm: &str = &args.realm;
         let (_, _, _) = futures::join!(
-            async { listen_event.listen().await },
+            async { Arc::new(listen_event).listen().await },
             async { run_service(http_addr.to_owned(), swarm_clone, key).await },
             async { run_udp_turn(public_ip, turn_port, username, password, realm).await }
         );

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -189,7 +189,7 @@ async fn daemon_run(http_addr: String, key: &SecretKey, stun: &str) -> anyhow::R
     let key = key.to_owned();
 
     let (_, _) = futures::join!(
-        listen_event.listen(),
+        Arc::new(listen_event).listen(),
         run_service(http_addr.to_owned(), swarm_clone, key)
     );
 

--- a/bns-core/src/types/message.rs
+++ b/bns-core/src/types/message.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
+use std::sync::Arc;
 
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
 pub trait MessageListener {
-    async fn listen(self);
+    async fn listen(self: Arc<Self>);
 }


### PR DESCRIPTION
```
#[cfg_attr(feature = "wasm", async_trait(?Send))]
#[cfg_attr(not(feature = "wasm"), async_trait)]
pub trait MessageListener {
    async fn listen(self: Arc<Self>);
}
```

instead of

```
#[cfg_attr(feature = "wasm", async_trait(?Send))]
#[cfg_attr(not(feature = "wasm"), async_trait)]
pub trait MessageListener {
    async fn listen(self);
}
```