### PR TITLE
update stabilize test and ice_server list

### DIFF
--- a/bns-core/src/dht/chord.rs
+++ b/bns-core/src/dht/chord.rs
@@ -61,6 +61,10 @@ impl Chord {
         }
     }
 
+    pub fn number_of_fingers(&self) -> usize {
+        self.finger.iter().flatten().count() as usize
+    }
+
     // join a Chord ring containing node id .
     pub fn join(&mut self, id: Did) -> ChordAction {
         if id == self.id {
@@ -96,7 +100,6 @@ impl Chord {
             // 2) #fff should follow #001 because id space is a Finate Ring
             // 3) #001 - #fff = #001 + -(#fff) = #001
             self.successor = id;
-            return ChordAction::None;
         }
         ChordAction::RemoteAction(self.successor, RemoteAction::FindSuccessor(self.id))
     }

--- a/bns-core/src/dht/chord.rs
+++ b/bns-core/src/dht/chord.rs
@@ -96,6 +96,7 @@ impl Chord {
             // 2) #fff should follow #001 because id space is a Finate Ring
             // 3) #001 - #fff = #001 + -(#fff) = #001
             self.successor = id;
+            return ChordAction::None;
         }
         ChordAction::RemoteAction(self.successor, RemoteAction::FindSuccessor(self.id))
     }

--- a/bns-core/src/message/handler.rs
+++ b/bns-core/src/message/handler.rs
@@ -17,6 +17,7 @@ use web_sys::RtcSdpType as RTCSdpType;
 #[cfg(not(feature = "wasm"))]
 use webrtc::peer_connection::sdp::sdp_type::RTCSdpType;
 
+#[derive(Clone)]
 pub struct MessageHandler {
     dht: Arc<Mutex<Chord>>,
     swarm: Arc<Swarm>,
@@ -83,10 +84,7 @@ impl MessageHandler {
         let mut dht = self.dht.lock().await;
         let relay = relay.clone();
         match dht.join(msg.id) {
-            ChordAction::None => {
-                log::debug!("Opps, {:?} is same as current", msg.id);
-                Ok(())
-            }
+            ChordAction::None => Ok(()),
             ChordAction::RemoteAction(next, ChordRemoteAction::FindSuccessor(id)) => {
                 if next != *prev {
                     self.send_message(

--- a/bns-core/src/message/handler.rs
+++ b/bns-core/src/message/handler.rs
@@ -83,10 +83,14 @@ impl MessageHandler {
     ) -> Result<()> {
         let mut dht = self.dht.lock().await;
         let relay = relay.clone();
+        // here is two situation.
+        // finger table just have no other node(beside next), it will be a `create` op
+        // otherwise, it will be a `send` op
+        let join_op = dht.number_of_fingers() > 0;
         match dht.join(msg.id) {
             ChordAction::None => Ok(()),
             ChordAction::RemoteAction(next, ChordRemoteAction::FindSuccessor(id)) => {
-                if next != *prev {
+                if next != *prev && join_op {
                     self.send_message(
                         &next.into(),
                         Some(relay.to_path),

--- a/bns-core/src/transports/default/transport.rs
+++ b/bns-core/src/transports/default/transport.rs
@@ -334,7 +334,6 @@ impl IceTransportCallback<Event, AcChannel<Event>> for DefaultTransport {
                         if desc.is_none() {
                             let mut candidates = pending_candidates.lock().await;
                             candidates.push(candidate.clone());
-                            println!("Candidates Number: {:?}", candidates.len());
                         }
                     }
                 }

--- a/bns-core/tests/default/mod.rs
+++ b/bns-core/tests/default/mod.rs
@@ -1,1 +1,2 @@
 pub mod test_message_handler;
+pub mod test_stabilize;

--- a/bns-core/tests/default/test_message_handler.rs
+++ b/bns-core/tests/default/test_message_handler.rs
@@ -12,8 +12,10 @@ pub mod test {
     use bns_core::transports::Transport;
     use bns_core::types::ice_transport::IceTransport;
     use bns_core::types::ice_transport::IceTrickleScheme;
+    use bns_core::types::message::MessageListener;
     use futures::lock::Mutex;
     use std::sync::Arc;
+    use tokio::time::{sleep, Duration};
     use webrtc::ice_transport::ice_connection_state::RTCIceConnectionState;
     use webrtc::peer_connection::sdp::sdp_type::RTCSdpType;
 
@@ -169,7 +171,7 @@ pub mod test {
         let dht3 = Arc::new(Mutex::new(new_chord(key3.address().into())));
 
         let (_, _) = establish_connection(Arc::clone(&swarm1), Arc::clone(&swarm2)).await?;
-        let (_, _) = establish_connection(Arc::clone(&swarm2), Arc::clone(&swarm3)).await?;
+        let (_, _) = establish_connection(Arc::clone(&swarm3), Arc::clone(&swarm2)).await?;
 
         let transport_1_to_3 = swarm1.new_transport().await.unwrap();
         let handshake_info13 = transport_1_to_3
@@ -183,86 +185,99 @@ pub mod test {
         let handler2 = MessageHandler::new(Arc::clone(&dht2), Arc::clone(&swarm2));
         let handler3 = MessageHandler::new(Arc::clone(&dht3), Arc::clone(&swarm3));
 
-        // handle join dht situation
-        handler1.listen_once().await;
-        handler2.listen_once().await;
-
-        handler3.listen_once().await;
-        handler2.listen_once().await;
-        let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
-        let transport_2_to_3 = swarm2.get_transport(&swarm3.address()).unwrap();
-        assert_eq!(
-            dht1.lock().await.successor,
-            key2.address().into(),
-            "dht1 successor is key2"
-        );
-        assert_eq!(
-            dht2.lock().await.successor,
-            key3.address().into(),
-            "dht2 successor is key3"
-        );
-        assert_eq!(
-            dht3.lock().await.successor,
-            key2.address().into(),
-            "dht3 successor is key2"
-        );
-
-        transport_1_to_2.wait_for_data_channel_open().await?;
-        transport_2_to_3.wait_for_data_channel_open().await?;
-        assert_eq!(
-            transport_1_to_2.ice_connection_state().await,
-            Some(RTCIceConnectionState::Connected)
-        );
-        assert_eq!(
-            transport_2_to_3.ice_connection_state().await,
-            Some(RTCIceConnectionState::Connected)
-        );
-        let connect_msg = Message::ConnectNode(message::ConnectNode {
-            sender_id: swarm1.address().into(),
-            target_id: swarm3.address().into(),
-            handshake_info: handshake_info13.to_string(),
-        });
-        handler1
-            .send_message(
-                &swarm2.address(),
-                None,
-                None,
-                MessageRelayMethod::SEND,
-                connect_msg.clone(),
-            )
-            .await?;
-        assert_eq!(
-            handler2.listen_once().await.unwrap().data,
-            Message::FindSuccessor(message::FindSuccessor {
-                id: swarm1.address().into(),
-                for_fix: false
-            })
-        );
-
-        handler3.listen_once().await;
-        handler2.listen_once().await;
-        handler3.listen_once().await;
-        handler2.listen_once().await;
-        handler1.listen_once().await;
-        handler3.listen_once().await;
-        handler3.listen_once().await;
-        handler2.listen_once().await;
-        handler2.listen_once().await;
-        handler1.listen_once().await;
-        let transport_1_to_3 = swarm1.get_transport(&swarm3.address());
-        assert!(transport_1_to_3.is_some());
-        let transport_1_to_3 = transport_1_to_3.unwrap();
-        assert_eq!(
-            transport_1_to_3.ice_connection_state().await,
-            Some(RTCIceConnectionState::New)
-        );
-        handler3.listen_once().await;
-        handler1.listen_once().await;
-        transport_1_to_3.wait_for_data_channel_open().await?;
-        assert_eq!(
-            transport_1_to_3.ice_connection_state().await,
-            Some(RTCIceConnectionState::Connected)
-        );
+        tokio::select! {
+            _ = async {
+                futures::join!(
+                    async {
+                        loop {
+                            Arc::new(handler1.clone()).listen().await;
+                        }
+                    },
+                    async {
+                        loop {
+                            Arc::new(handler2.clone()).listen().await;
+                        }
+                    },
+                    async {
+                        loop {
+                            Arc::new(handler3.clone()).listen().await;
+                        }
+                    }
+                )
+            } => {unreachable!();}
+            _ = async {
+                // handle join dht situation
+                let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
+                transport_1_to_2.wait_for_data_channel_open().await.unwrap();
+                sleep(Duration::from_millis(1000)).await;
+                let transport_3_to_2 = swarm3.get_transport(&swarm2.address()).unwrap();
+                transport_3_to_2.wait_for_data_channel_open().await.unwrap();
+                sleep(Duration::from_millis(1000)).await;
+                println!(
+                    "swarm1 key: {:?}, swarm2 key: {:?}, swarm3 key: {:?}",
+                    swarm1.address(),
+                    swarm2.address(),
+                    swarm3.address()
+                );
+                println!(
+                    "dht1 successor: {:?}, dht2 successor: {:?}, dht3 successor: {:?}",
+                    dht1.lock().await.successor,
+                    dht2.lock().await.successor,
+                    dht3.lock().await.successor
+                );
+                assert_eq!(
+                    dht1.lock().await.successor,
+                    key2.address().into(),
+                    "dht1 successor is key2"
+                );
+                assert_eq!(
+                    dht2.lock().await.successor,
+                    key3.address().into(),
+                    "dht2 successor is key3"
+                );
+                assert_eq!(
+                    dht3.lock().await.successor,
+                    key2.address().into(),
+                    "dht3 successor is key2"
+                );
+                assert_eq!(
+                    transport_1_to_2.ice_connection_state().await,
+                    Some(RTCIceConnectionState::Connected)
+                );
+                assert_eq!(
+                    transport_3_to_2.ice_connection_state().await,
+                    Some(RTCIceConnectionState::Connected)
+                );
+                let connect_msg = Message::ConnectNode(message::ConnectNode {
+                    sender_id: swarm1.address().into(),
+                    target_id: swarm3.address().into(),
+                    handshake_info: handshake_info13.to_string(),
+                });
+                handler1
+                    .send_message(
+                        &swarm2.address(),
+                        None,
+                        None,
+                        MessageRelayMethod::SEND,
+                        connect_msg.clone(),
+                    )
+                    .await
+                    .unwrap();
+                sleep(Duration::from_millis(1000)).await;
+                let transport_1_to_3 = swarm1.get_transport(&swarm3.address());
+                assert!(transport_1_to_3.is_some());
+                let transport_1_to_3 = transport_1_to_3.unwrap();
+                assert_eq!(
+                    transport_1_to_3.ice_connection_state().await,
+                    Some(RTCIceConnectionState::Checking)
+                );
+                transport_1_to_3.wait_for_data_channel_open().await.unwrap();
+                assert_eq!(
+                    transport_1_to_3.ice_connection_state().await,
+                    Some(RTCIceConnectionState::Connected)
+                );
+            } => {}
+        }
         Ok(())
     }
 
@@ -279,32 +294,48 @@ pub mod test {
         let handler2 = MessageHandler::new(Arc::clone(&dht2), Arc::clone(&swarm2));
 
         // handle join dht situation
-        handler1.listen_once().await;
-        handler2.listen_once().await;
+        tokio::select! {
+            _ = async {
+                futures::join!(
+                    async {
+                        loop {
+                            Arc::new(handler1.clone()).listen().await;
+                        }
+                    },
+                    async {
+                        loop {
+                            Arc::new(handler2.clone()).listen().await;
+                        }
+                    }
+                );
+            } => { unreachable!();}
+            _ = async {
+                let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
+                transport_1_to_2.wait_for_data_channel_open().await.unwrap();
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+                assert_eq!(dht2.lock().await.successor, key1.address().into());
+                assert_eq!(
+                    transport_1_to_2.ice_connection_state().await,
+                    Some(RTCIceConnectionState::Connected)
+                );
+                handler1
+                    .send_message(
+                        &swarm2.address(),
+                        None,
+                        None,
+                        MessageRelayMethod::SEND,
+                        Message::NotifyPredecessor(message::NotifyPredecessor {
+                            id: key1.address().into(),
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                sleep(Duration::from_millis(1000)).await;
+                assert_eq!(dht2.lock().await.predecessor, Some(key1.address().into()));
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+            } => {}
+        }
 
-        let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
-        assert_eq!(dht1.lock().await.successor, key2.address().into());
-        assert_eq!(dht2.lock().await.successor, key1.address().into());
-        assert_eq!(
-            transport_1_to_2.ice_connection_state().await,
-            Some(RTCIceConnectionState::Connected)
-        );
-        transport_1_to_2.wait_for_data_channel_open().await?;
-        handler1
-            .send_message(
-                &swarm2.address(),
-                None,
-                None,
-                MessageRelayMethod::SEND,
-                Message::NotifyPredecessor(message::NotifyPredecessor {
-                    id: key1.address().into(),
-                }),
-            )
-            .await?;
-        handler2.listen_once().await;
-        assert_eq!(dht2.lock().await.predecessor, Some(key1.address().into()));
-        handler1.listen_once().await;
-        assert_eq!(dht1.lock().await.successor, key2.address().into());
         Ok(())
     }
 
@@ -325,53 +356,69 @@ pub mod test {
         let handler2 = MessageHandler::new(Arc::clone(&dht2), Arc::clone(&swarm2));
 
         // handle join dht situation
-        handler1.listen_once().await;
-        handler2.listen_once().await;
-        let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
-        assert_eq!(dht1.lock().await.successor, key2.address().into());
-        assert_eq!(dht2.lock().await.successor, key1.address().into());
-        assert_eq!(
-            transport_1_to_2.ice_connection_state().await,
-            Some(RTCIceConnectionState::Connected)
-        );
-        transport_1_to_2.wait_for_data_channel_open().await?;
-        handler1
-            .send_message(
-                &swarm2.address(),
-                None,
-                None,
-                MessageRelayMethod::SEND,
-                Message::NotifyPredecessor(message::NotifyPredecessor {
-                    id: swarm1.address().into(),
-                }),
-            )
-            .await?;
-        handler2.listen_once().await;
-        assert_eq!(dht2.lock().await.predecessor, Some(key1.address().into()));
-        handler1.listen_once().await;
-        assert_eq!(dht1.lock().await.successor, key2.address().into());
+        tokio::select! {
+            _ = async {
+                futures::join!(
+                    async {
+                        loop {
+                            Arc::new(handler1.clone()).listen().await;
+                        }
+                    },
+                    async {
+                        loop {
+                            Arc::new(handler2.clone()).listen().await;
+                        }
+                    }
+                );
+            } => { unreachable!();}
+            _ = async {
+                let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
+                transport_1_to_2.wait_for_data_channel_open().await.unwrap();
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+                assert_eq!(dht2.lock().await.successor, key1.address().into());
+                assert_eq!(
+                    transport_1_to_2.ice_connection_state().await,
+                    Some(RTCIceConnectionState::Connected)
+                );
+                handler1
+                    .send_message(
+                        &swarm2.address(),
+                        None,
+                        None,
+                        MessageRelayMethod::SEND,
+                        Message::NotifyPredecessor(message::NotifyPredecessor {
+                            id: swarm1.address().into(),
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                sleep(Duration::from_millis(1000)).await;
+                assert_eq!(dht2.lock().await.predecessor, Some(key1.address().into()));
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
 
-        println!(
-            "swarm1: {:?}, swarm2: {:?}",
-            swarm1.address(),
-            swarm2.address()
-        );
-        handler2
-            .send_message(
-                &swarm1.address(),
-                None,
-                None,
-                MessageRelayMethod::SEND,
-                Message::FindSuccessor(message::FindSuccessor {
-                    id: swarm2.address().into(),
-                    for_fix: false,
-                }),
-            )
-            .await?;
-        handler1.listen_once().await;
-        handler2.listen_once().await;
-        //assert_eq!(dht2.lock().await.successor, key2.address().into());
-        //assert_eq!(dht1.lock().await.successor, key2.address().into());
+                println!(
+                    "swarm1: {:?}, swarm2: {:?}",
+                    swarm1.address(),
+                    swarm2.address()
+                );
+                handler2
+                    .send_message(
+                        &swarm1.address(),
+                        None,
+                        None,
+                        MessageRelayMethod::SEND,
+                        Message::FindSuccessor(message::FindSuccessor {
+                            id: swarm2.address().into(),
+                            for_fix: false,
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                sleep(Duration::from_millis(1000)).await;
+                assert_eq!(dht2.lock().await.successor, key2.address().into());
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+            } => {}
+        }
         Ok(())
     }
 
@@ -393,65 +440,78 @@ pub mod test {
         let handler2 = MessageHandler::new(Arc::clone(&dht2), Arc::clone(&swarm2));
 
         // handle join dht situation
-        handler1.listen_once().await;
-        handler2.listen_once().await;
-        let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
-        assert_eq!(dht1.lock().await.successor, key2.address().into());
-        assert_eq!(dht2.lock().await.successor, key1.address().into());
-
-        assert!(dht1
-            .lock()
-            .await
-            .finger
-            .contains(&Some(key2.address().into())));
-        assert!(dht2
-            .lock()
-            .await
-            .finger
-            .contains(&Some(key1.address().into())));
-
-        assert_eq!(
-            transport_1_to_2.ice_connection_state().await,
-            Some(RTCIceConnectionState::Connected)
-        );
-        transport_1_to_2.wait_for_data_channel_open().await?;
-        handler1
-            .send_message(
-                &swarm2.address(),
-                None,
-                None,
-                MessageRelayMethod::SEND,
-                Message::NotifyPredecessor(message::NotifyPredecessor {
-                    id: swarm1.address().into(),
-                }),
-            )
-            .await?;
-        handler2.listen_once().await;
-        assert_eq!(dht2.lock().await.predecessor, Some(key1.address().into()));
-        handler1.listen_once().await;
-        assert_eq!(dht1.lock().await.successor, key2.address().into());
-
-        println!(
-            "swarm1: {:?}, swarm2: {:?}",
-            swarm1.address(),
-            swarm2.address()
-        );
-        handler2
-            .send_message(
-                &swarm1.address(),
-                None,
-                None,
-                MessageRelayMethod::SEND,
-                Message::FindSuccessor(message::FindSuccessor {
-                    id: swarm2.address().into(),
-                    for_fix: false,
-                }),
-            )
-            .await?;
-        assert!(handler1.listen_once().await.is_some());
-        //        handler2.listen_once().await;
-        assert_eq!(dht2.lock().await.successor, key1.address().into());
-        assert_eq!(dht1.lock().await.successor, key2.address().into());
+        tokio::select! {
+            _ = async {
+                futures::join!(
+                    async {
+                        loop {
+                            Arc::new(handler1.clone()).listen().await;
+                        }
+                    },
+                    async {
+                        loop {
+                            Arc::new(handler2.clone()).listen().await;
+                        }
+                    }
+                );
+            } => {unreachable!();}
+            _ = async {
+                let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
+                transport_1_to_2.wait_for_data_channel_open().await.unwrap();
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+                assert_eq!(dht2.lock().await.successor, key1.address().into());
+                assert!(dht1
+                    .lock()
+                    .await
+                    .finger
+                    .contains(&Some(key2.address().into())));
+                assert!(dht2
+                    .lock()
+                    .await
+                    .finger
+                    .contains(&Some(key1.address().into())));
+                assert_eq!(
+                    transport_1_to_2.ice_connection_state().await,
+                    Some(RTCIceConnectionState::Connected)
+                );
+                handler1
+                    .send_message(
+                        &swarm2.address(),
+                        None,
+                        None,
+                        MessageRelayMethod::SEND,
+                        Message::NotifyPredecessor(message::NotifyPredecessor {
+                            id: swarm1.address().into(),
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                sleep(Duration::from_millis(1000)).await;
+                assert_eq!(dht2.lock().await.predecessor, Some(key1.address().into()));
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+                println!(
+                    "swarm1: {:?}, swarm2: {:?}",
+                    swarm1.address(),
+                    swarm2.address()
+                );
+                handler2
+                    .send_message(
+                        &swarm1.address(),
+                        None,
+                        None,
+                        MessageRelayMethod::SEND,
+                        Message::FindSuccessor(message::FindSuccessor {
+                            id: swarm2.address().into(),
+                            for_fix: false,
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                sleep(Duration::from_millis(1000)).await;
+                assert_eq!(dht2.lock().await.successor, key1.address().into());
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+            } => {}
+        };
         Ok(())
     }
 }

--- a/bns-core/tests/default/test_message_handler.rs
+++ b/bns-core/tests/default/test_message_handler.rs
@@ -267,10 +267,11 @@ pub mod test {
                 let transport_1_to_3 = swarm1.get_transport(&swarm3.address());
                 assert!(transport_1_to_3.is_some());
                 let transport_1_to_3 = transport_1_to_3.unwrap();
-                assert_eq!(
-                    transport_1_to_3.ice_connection_state().await,
-                    Some(RTCIceConnectionState::Checking)
-                );
+                let both = {
+                    transport_1_to_3.ice_connection_state().await == Some(RTCIceConnectionState::New) ||
+                        transport_1_to_3.ice_connection_state().await == Some(RTCIceConnectionState::Checking)
+                };
+                assert!(both);
                 transport_1_to_3.wait_for_data_channel_open().await.unwrap();
                 assert_eq!(
                     transport_1_to_3.ice_connection_state().await,

--- a/bns-core/tests/default/test_stabilize.rs
+++ b/bns-core/tests/default/test_stabilize.rs
@@ -1,0 +1,240 @@
+#[cfg(test)]
+pub mod test {
+    use bns_core::dht::Stabilization;
+    use bns_core::dht::{Chord, Did};
+    use bns_core::ecc::SecretKey;
+    use bns_core::err::Result;
+    use bns_core::message::handler::MessageHandler;
+    use bns_core::session::SessionManager;
+    use bns_core::swarm::Swarm;
+    use bns_core::swarm::TransportManager;
+    use bns_core::transports::Transport;
+    use bns_core::types::ice_transport::IceTransport;
+    use bns_core::types::ice_transport::IceTrickleScheme;
+    use bns_core::types::message::MessageListener;
+    use futures::lock::Mutex;
+    use std::sync::Arc;
+    use tokio::time::{sleep, Duration};
+    use webrtc::ice_transport::ice_connection_state::RTCIceConnectionState;
+    use webrtc::peer_connection::sdp::sdp_type::RTCSdpType;
+
+    fn new_chord(did: Did) -> Chord {
+        Chord::new(did)
+    }
+
+    fn new_swarm(key: &SecretKey) -> Swarm {
+        let stun = "stun://stun.l.google.com:19302";
+        let session = SessionManager::new_with_seckey(key).unwrap();
+        Swarm::new(stun, key.address(), session)
+    }
+
+    pub async fn establish_connection(
+        swarm1: Arc<Swarm>,
+        swarm2: Arc<Swarm>,
+    ) -> Result<(Arc<Transport>, Arc<Transport>)> {
+        assert!(swarm1.get_transport(&swarm2.address()).is_none());
+        assert!(swarm2.get_transport(&swarm1.address()).is_none());
+
+        let transport1 = swarm1.new_transport().await.unwrap();
+        let transport2 = swarm2.new_transport().await.unwrap();
+
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+
+        // Peer 1 try to connect peer 2
+        let handshake_info1 = transport1
+            .get_handshake_info(swarm1.session(), RTCSdpType::Offer)
+            .await?;
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+
+        // Peer 2 got offer then register
+        let addr1 = transport2.register_remote_info(handshake_info1).await?;
+        assert_eq!(addr1, swarm1.address());
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+
+        // Peer 2 create answer
+        let handshake_info2 = transport2
+            .get_handshake_info(swarm2.session(), RTCSdpType::Answer)
+            .await?;
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::Checking)
+        );
+
+        // Peer 1 got answer then register
+        let addr2 = transport1.register_remote_info(handshake_info2).await?;
+        assert_eq!(addr2, swarm2.address());
+        let promise_1 = transport1.connect_success_promise().await?;
+        let promise_2 = transport2.connect_success_promise().await?;
+        promise_1.await?;
+        promise_2.await?;
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RTCIceConnectionState::Connected)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RTCIceConnectionState::Connected)
+        );
+        swarm1
+            .register(&swarm2.address(), transport1.clone())
+            .await?;
+        swarm2
+            .register(&swarm1.address(), transport2.clone())
+            .await?;
+        let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
+        let transport_2_to_1 = swarm2.get_transport(&swarm1.address()).unwrap();
+
+        assert!(Arc::ptr_eq(&transport_1_to_2, &transport1));
+        assert!(Arc::ptr_eq(&transport_2_to_1, &transport2));
+
+        Ok((transport1, transport2))
+    }
+
+    async fn run_stabilize(chord: Arc<Mutex<Chord>>, swarm: Arc<Swarm>) {
+        let mut result = Result::<()>::Ok(());
+        let stabilization = Stabilization::new(chord, swarm, 5usize);
+        let timeout_in_secs = stabilization.get_timeout();
+        println!("RUN Stabilization");
+        while result.is_ok() {
+            let timeout = sleep(Duration::from_secs(timeout_in_secs as u64));
+            tokio::pin!(timeout);
+            tokio::select! {
+                _ = timeout.as_mut() => {
+                    result = stabilization
+                        .stabilize()
+                        .await;
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stabilization_once() -> Result<()> {
+        let mut key1 = SecretKey::random();
+        let mut key2 = SecretKey::random();
+        // key 2 > key 1 here
+        if key1.address() < key2.address() {
+            (key1, key2) = (key2, key1)
+        }
+        let dht1 = Arc::new(Mutex::new(new_chord(key1.address().into())));
+        let dht2 = Arc::new(Mutex::new(new_chord(key2.address().into())));
+        let swarm1 = Arc::new(new_swarm(&key1));
+        let swarm2 = Arc::new(new_swarm(&key2));
+        let (_, _) = establish_connection(Arc::clone(&swarm1), Arc::clone(&swarm2)).await?;
+
+        let handler1 = MessageHandler::new(Arc::clone(&dht1), Arc::clone(&swarm1));
+        let handler2 = MessageHandler::new(Arc::clone(&dht2), Arc::clone(&swarm2));
+        println!(
+            "swarm1: {:?}, swarm2: {:?}",
+            swarm1.address(),
+            swarm2.address()
+        );
+
+        tokio::select! {
+            _ = async {
+                futures::join!(
+                    async {
+                        loop {
+                            Arc::new(handler1.clone()).listen().await;
+                        }
+                    },
+                    async {
+                        loop {
+                            Arc::new(handler2.clone()).listen().await;
+                        }
+                    },
+                );
+            } => { unreachable!(); }
+            _ = async {
+                let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
+                transport_1_to_2.wait_for_data_channel_open().await.unwrap();
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+                assert_eq!(dht2.lock().await.successor, key1.address().into());
+                let stabilization = Stabilization::new(Arc::clone(&dht1), Arc::clone(&swarm1), 5usize);
+                let _ = stabilization.stabilize().await;
+                sleep(Duration::from_millis(10000)).await;
+                assert_eq!(dht2.lock().await.predecessor, Some(key1.address().into()));
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+            } => {}
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stabilization() -> Result<()> {
+        let mut key1 = SecretKey::random();
+        let mut key2 = SecretKey::random();
+        // key 2 > key 1 here
+        if key1.address() < key2.address() {
+            (key1, key2) = (key2, key1)
+        }
+        let dht1 = Arc::new(Mutex::new(new_chord(key1.address().into())));
+        let dht2 = Arc::new(Mutex::new(new_chord(key2.address().into())));
+        let swarm1 = Arc::new(new_swarm(&key1));
+        let swarm2 = Arc::new(new_swarm(&key2));
+        let (_, _) = establish_connection(Arc::clone(&swarm1), Arc::clone(&swarm2)).await?;
+
+        let handler1 = MessageHandler::new(Arc::clone(&dht1), Arc::clone(&swarm1));
+        let handler2 = MessageHandler::new(Arc::clone(&dht2), Arc::clone(&swarm2));
+
+        tokio::select! {
+            _ = async {
+                tokio::join!(
+                    async {
+                        loop {
+                            Arc::new(handler1.clone()).listen().await;
+                        }
+                    },
+                    async {
+                        loop {
+                            Arc::new(handler2.clone()).listen().await;
+                        }
+                    },
+                    async {
+                        run_stabilize(Arc::clone(&dht1), Arc::clone(&swarm1)).await;
+                    },
+                    async {
+                        run_stabilize(Arc::clone(&dht2), Arc::clone(&swarm2)).await;
+                    }
+                );
+            } => { unreachable!(); }
+            _ = async {
+                let transport_1_to_2 = swarm1.get_transport(&swarm2.address()).unwrap();
+                transport_1_to_2.wait_for_data_channel_open().await.unwrap();
+                assert_eq!(dht1.lock().await.successor, key2.address().into());
+                assert_eq!(dht2.lock().await.successor, key1.address().into());
+                sleep(Duration::from_millis(10000)).await;
+                assert_eq!(dht2.lock().await.predecessor, Some(key1.address().into()));
+                assert_eq!(dht1.lock().await.predecessor, Some(key2.address().into()));
+            } => {}
+        }
+
+        Ok(())
+    }
+}

--- a/bns-core/tests/wasm/test_message_handler.rs
+++ b/bns-core/tests/wasm/test_message_handler.rs
@@ -1,0 +1,130 @@
+#[cfg(test)]
+pub mod test {
+    use bns_core::dht::{Chord, Did};
+    use bns_core::channels::Channel as CbChannel;
+    use bns_core::ecc::SecretKey;
+    use bns_core::err::Result;
+    use bns_core::session::SessionManager;
+    use bns_core::swarm::Swarm;
+    use bns_core::swarm::TransportManager;
+    use bns_core::transports::Transport;
+    use bns_core::types::channel::Channel;
+    use bns_core::types::channel::Event;
+    use bns_core::types::ice_transport::IceServer;
+    use bns_core::types::ice_transport::IceTransport;
+    use bns_core::types::ice_transport::IceTransportCallback;
+    use bns_core::types::ice_transport::IceTrickleScheme;
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    use wasm_bindgen_test::*;
+    use web_sys::RtcIceConnectionState;
+    use web_sys::RtcSdpType;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn new_chord(did: Did) -> Chord {
+        Chord::new(did)
+    }
+
+    fn new_swarm(key: &SecretKey) -> Swarm {
+        let stun = "stun://stun.l.google.com:19302";
+        let session = SessionManager::new_with_seckey(key).unwrap();
+        Swarm::new(stun, key.address(), session)
+    }
+
+    async fn prepare_transport(channel: Option<Arc<CbChannel<Event>>>) -> Result<Transport> {
+        let ch = match channel {
+            Some(c) => Arc::clone(&c),
+            None => Arc::new(<CbChannel<Event> as Channel<Event>>::new(1)),
+        };
+        let mut trans = Transport::new(ch.sender());
+        let stun = IceServer::from_str("stun://stun.l.google.com:19302").unwrap();
+        trans.start(&stun).await.unwrap();
+        trans.apply_callback().await.unwrap();
+        Ok(trans)
+    }
+
+    pub async fn establish_connection(
+        transport1: &Transport,
+        transport2: &Transport,
+    ) -> Result<()> {
+        // Generate key pairs for signing and verification
+        let key1 = SecretKey::random();
+        let key2 = SecretKey::random();
+
+        let session1 = SessionManager::new_with_seckey(&key1).unwrap();
+        let session2 = SessionManager::new_with_seckey(&key2).unwrap();
+
+        // Peer 1 try to connect peer 2
+        let handshake_info1 = transport1
+            .get_handshake_info(session1, RtcSdpType::Offer)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RtcIceConnectionState::New)
+        );
+
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RtcIceConnectionState::New)
+        );
+
+        // Peer 2 got offer then register
+        let addr1 = transport2.register_remote_info(handshake_info1).await?;
+
+        assert_eq!(addr1, key1.address());
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RtcIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RtcIceConnectionState::New)
+        );
+
+        // Peer 2 create answer
+        let handshake_info2 = transport2
+            .get_handshake_info(session2, RtcSdpType::Answer)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            transport1.ice_connection_state().await,
+            Some(RtcIceConnectionState::New)
+        );
+        assert_eq!(
+            transport2.ice_connection_state().await,
+            Some(RtcIceConnectionState::Checking)
+        );
+
+        // Peer 1 got answer then register
+        let addr2 = transport1
+            .register_remote_info(handshake_info2)
+            .await
+            .unwrap();
+        // assert_eq!(
+        //     transport1.ice_connection_state().await,
+        //     Some(RtcIceConnectionState::Checking)
+        // );
+
+        assert_eq!(addr2, key2.address());
+        // let promise_1 = transport1.connect_success_promise().await.unwrap();
+        // let promise_2 = transport2.connect_success_promise().await.unwrap();
+        // promise_1.await.unwrap();
+        // promise_2.await.unwrap();
+        // assert_eq!(
+        //     transport1.ice_connection_state().await,
+        //     Some(RtcIceConnectionState::Connected)
+        // );
+        // assert_eq!(
+        //     transport2.ice_connection_state().await,
+        //     Some(RtcIceConnectionState::Connected)
+        // );
+        Ok(())
+    }
+}
+


### PR DESCRIPTION
1. refine unittest, remove `listen_once` and use futures::join as background programs
2. `handle_join` should consider two situation, first of all is `fingers` is empty, juse join local and set successor, others need send remote message find successor
3. parse ice_server as a stun list